### PR TITLE
fixed 'editor.html' incorrectly referencing minified version for 'ooxml' engine

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -75,7 +75,7 @@
 </div>
 <div id="canvas"></div>
 <script src="https://cdn.rawgit.com/jsFile/jsFile/master/dist/jsfile.min.js"></script>
-<script src="https://cdn.rawgit.com/jsFile/jsFile-ooxml/master/dist/jsfile-ooxml.min.js"></script>
+<script src="https://cdn.rawgit.com/jsFile/jsFile-ooxml/master/dist/jsfile-ooxml.js"></script>
 <script src="https://cdn.rawgit.com/jsFile/jsFile-odf/master/dist/jsfile-odf.min.js"></script>
 <script src="https://cdn.rawgit.com/jsFile/jsFile-epub/master/dist/jsfile-epub.min.js"></script>
 <script src="https://cdn.rawgit.com/jsFile/jsFile-image/master/dist/jsfile-image.min.js"></script>


### PR DESCRIPTION
Currently demo is crashing due to referencing of the non-existing JS file for 'ooxml' engine.
This PR fixes 'editor.html' file referencing minified version for 'ooxml' engine that doesn't exist in the repo.